### PR TITLE
tests

### DIFF
--- a/server/Models/tests.cs
+++ b/server/Models/tests.cs
@@ -1,0 +1,34 @@
+using Xunit;
+using Tailwind.Mail.Models;
+
+namespace Tailwind.Mail.Tests
+{
+    public class BroadcastTests
+    {
+        [Fact]
+        public void Broadcast_SetAndGetProperties_ShouldWorkCorrectly()
+        {
+            // Arrange
+            var broadcast = new Broadcast();
+            int? id = 1;
+            int? emailId = 2;
+            string status = "sent";
+            string name = "Test Broadcast";
+            string slug = "test-broadcast";
+
+            // Act
+            broadcast.ID = id;
+            broadcast.EmailId = emailId;
+            broadcast.Status = status;
+            broadcast.Name = name;
+            broadcast.Slug = slug;
+
+            // Assert
+            Assert.Equal(id, broadcast.ID);
+            Assert.Equal(emailId, broadcast.EmailId);
+            Assert.Equal(status, broadcast.Status);
+            Assert.Equal(name, broadcast.Name);
+            Assert.Equal(slug, broadcast.Slug);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces unit tests for the `Broadcast` class in the `server/Models` directory. The changes ensure that the properties of the `Broadcast` class can be set and retrieved correctly.

Unit tests added:

* [`server/Models/tests.cs`](diffhunk://#diff-2ab8dc8d28fda1e5a565ce0b32b97b7088be4106bb73b7622db1b3e49fe3fc37R1-R34): Added unit tests using the `Xunit` framework to verify that the properties of the `Broadcast` class (`ID`, `EmailId`, `Status`, `Name`, and `Slug`) can be set and retrieved as expected.