### PR TITLE
Add testing for accessibility, Playwright, and mocked API

### DIFF
--- a/server/Tests/AccessibilityTests.cs
+++ b/server/Tests/AccessibilityTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.Playwright;
+using Microsoft.Playwright.NUnit;
+using AxeCore.NET;
+
+public class AccessibilityTests : PageTest
+{
+    [Fact]
+    public async Task CheckAccessibility()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+
+        var axeBuilder = new AxeBuilder(Page);
+        var results = await axeBuilder.AnalyzeAsync();
+
+        Assert.Empty(results.Violations);
+    }
+
+    [Fact]
+    public async Task CheckButtonAccessibility()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+
+        var button = await Page.QuerySelectorAsync("button");
+        var axeBuilder = new AxeBuilder(button);
+        var results = await axeBuilder.AnalyzeAsync();
+
+        Assert.Empty(results.Violations);
+    }
+
+    [Fact]
+    public async Task CheckFormAccessibility()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+
+        var form = await Page.QuerySelectorAsync("form");
+        var axeBuilder = new AxeBuilder(form);
+        var results = await axeBuilder.AnalyzeAsync();
+
+        Assert.Empty(results.Violations);
+    }
+}

--- a/server/Tests/MockApiTests.cs
+++ b/server/Tests/MockApiTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+public class MockApiTests
+{
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+
+    public MockApiTests()
+    {
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+    }
+
+    [Fact]
+    public async Task Test_GetEndpoint_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var expectedResponse = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"message\":\"Hello, World!\"}")
+        };
+
+        _mockHttpMessageHandler
+            .Setup(handler => handler.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var response = await _httpClient.GetAsync("https://api.example.com/endpoint");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal("{\"message\":\"Hello, World!\"}", content);
+    }
+
+    [Fact]
+    public async Task Test_PostEndpoint_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var expectedResponse = new HttpResponseMessage(System.Net.HttpStatusCode.Created)
+        {
+            Content = new StringContent("{\"id\":1,\"message\":\"Created\"}")
+        };
+
+        _mockHttpMessageHandler
+            .Setup(handler => handler.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        var postData = new StringContent("{\"name\":\"Test\"}");
+
+        // Act
+        var response = await _httpClient.PostAsync("https://api.example.com/endpoint", postData);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal("{\"id\":1,\"message\":\"Created\"}", content);
+    }
+}

--- a/server/Tests/PlaywrightTests.cs
+++ b/server/Tests/PlaywrightTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.Playwright;
+using Microsoft.Playwright.NUnit;
+
+public class PlaywrightTests : PageTest
+{
+    [Fact]
+    public async Task CheckHomePageTitle()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+        Assert.Equal("Home - Tailwind Traders", await Page.TitleAsync());
+    }
+
+    [Fact]
+    public async Task CheckButtonExists()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+        var button = await Page.QuerySelectorAsync("button");
+        Assert.NotNull(button);
+    }
+
+    [Fact]
+    public async Task CheckFormExists()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+        var form = await Page.QuerySelectorAsync("form");
+        Assert.NotNull(form);
+    }
+
+    [Fact]
+    public async Task CheckLinkExists()
+    {
+        await Page.GotoAsync("http://localhost:5000");
+        var link = await Page.QuerySelectorAsync("a");
+        Assert.NotNull(link);
+    }
+}


### PR DESCRIPTION
Fixes #19

Add tests for accessibility, interface assertions, and mocked API.

* **Accessibility Tests**: Add `server/Tests/AccessibilityTests.cs` to check for accessibility issues using Axe. Tests include checking the main page, buttons, and forms for accessibility violations.
* **Playwright Tests**: Add `server/Tests/PlaywrightTests.cs` to perform interface assertions using Playwright. Tests include checking the home page title, existence of buttons, forms, and links.
* **Mocked API Tests**: Add `server/Tests/MockApiTests.cs` to mock API responses and test functionality. Tests include GET and POST endpoint responses with expected content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scubaninja/dotNET-mail-demo/issues/19?shareId=a615ec5e-69dc-40c6-bd08-8a8a188f2cb1).