### PR TITLE
Add PublicController and MarkdownEmail model with tests

### DIFF
--- a/src/main/java/com/tailwind/mail/controllers/PublicController.java
+++ b/src/main/java/com/tailwind/mail/controllers/PublicController.java
@@ -1,0 +1,46 @@
+package com.tailwind.mail.controllers;
+
+import com.tailwind.mail.commands.ContactOptOutCommand;
+import com.tailwind.mail.commands.LinkClickedCommand;
+import com.tailwind.mail.models.Contact;
+import com.tailwind.mail.models.SignUpRequest;
+import com.tailwind.mail.repositories.ContactRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class PublicController {
+
+    private final ContactRepository contactRepository;
+
+    public PublicController(ContactRepository contactRepository) {
+        this.contactRepository = contactRepository;
+    }
+
+    @GetMapping("/about")
+    @Operation(summary = "Information about the API")
+    public String about() {
+        return "Tailwind Traders Mail Services API";
+    }
+
+    @GetMapping("/unsubscribe/{key}")
+    @Operation(summary = "Unsubscribe from the mailing list")
+    public boolean unsubscribe(@PathVariable String key) {
+        return new ContactOptOutCommand(key).execute();
+    }
+
+    @GetMapping("/link/clicked/{key}")
+    @Operation(summary = "Track a link click")
+    public boolean linkClicked(@PathVariable String key) {
+        return new LinkClickedCommand(key).execute();
+    }
+
+    @PostMapping("/signup")
+    @Operation(summary = "Sign up for the mailing list")
+    public Contact signup(@RequestBody SignUpRequest request) {
+        Contact contact = new Contact();
+        contact.setEmail(request.getEmail());
+        contact.setName(request.getName());
+        return contactRepository.save(contact);
+    }
+}

--- a/src/main/java/com/tailwind/mail/models/MarkdownEmail.java
+++ b/src/main/java/com/tailwind/mail/models/MarkdownEmail.java
@@ -1,0 +1,66 @@
+package com.tailwind.mail.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MarkdownEmail {
+    private String markdown;
+    private String html;
+    private Map<String, Object> data;
+    private List<String> tags = new ArrayList<>();
+
+    public static MarkdownEmail fromFile(String path) throws IOException {
+        MarkdownEmail email = new MarkdownEmail();
+        email.markdown = Files.readString(new File(path).toPath());
+        email.render();
+        return email;
+    }
+
+    public static MarkdownEmail fromString(String markdown) {
+        MarkdownEmail email = new MarkdownEmail();
+        email.markdown = markdown;
+        email.render();
+        return email;
+    }
+
+    public boolean isValid() {
+        return data != null && data.containsKey("subject") && data.containsKey("summary");
+    }
+
+    private void render() {
+        if (markdown == null) {
+            throw new IllegalStateException("Markdown is null; be sure to set that first");
+        }
+
+        // Convert markdown to HTML
+        Parser parser = Parser.builder().build();
+        HtmlRenderer renderer = HtmlRenderer.builder().build();
+        html = renderer.render(parser.parse(markdown));
+
+        // Parse YAML front matter
+        Yaml yaml = new Yaml();
+        String[] parts = markdown.split("---", 3);
+        if (parts.length >= 2) {
+            data = yaml.load(parts[1]);
+            if (!data.containsKey("slug")) {
+                data.put("slug", ((String) data.get("subject")).toLowerCase().replace(" ", "-"));
+            }
+            if (!data.containsKey("sendToTag")) {
+                data.put("sendToTag", "*");
+            }
+        }
+    }
+
+    // Getters and setters
+    // ...existing code...
+}

--- a/src/test/java/com/tailwind/mail/controllers/PublicControllerTests.java
+++ b/src/test/java/com/tailwind/mail/controllers/PublicControllerTests.java
@@ -1,0 +1,57 @@
+package com.tailwind.mail.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tailwind.mail.models.SignUpRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PublicControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testAbout() throws Exception {
+        mockMvc.perform(get("/about"))
+               .andExpect(status().isOk())
+               .andExpect(content().string("Tailwind Traders Mail Services API"));
+    }
+
+    @Test
+    public void testSignup() throws Exception {
+        SignUpRequest request = new SignUpRequest();
+        request.setEmail("test@example.com");
+        request.setName("Test User");
+
+        mockMvc.perform(post("/signup")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsString(request)))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.email").value("test@example.com"))
+               .andExpect(jsonPath("$.name").value("Test User"));
+    }
+
+    @Test
+    public void testUnsubscribe() throws Exception {
+        mockMvc.perform(get("/unsubscribe/test-key"))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testLinkClicked() throws Exception {
+        mockMvc.perform(get("/link/clicked/test-key"))
+               .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `PublicController` class to handle public-facing API endpoints, a `MarkdownEmail` model for processing markdown emails, and test cases for the `PublicController` endpoints. The most important changes include the creation of the `PublicController` class, the implementation of the `MarkdownEmail` model, and the addition of test cases for the new controller.

### New PublicController:

* [`src/main/java/com/tailwind/mail/controllers/PublicController.java`](diffhunk://#diff-47d21b32e101c4cd78a0c6e1b106115082ad74d29f933b7ec77ea93083a5db11R1-R46): Added a new `PublicController` class to handle public-facing API endpoints, including methods for `about`, `unsubscribe`, `linkClicked`, and `signup`.

### MarkdownEmail Model:

* [`src/main/java/com/tailwind/mail/models/MarkdownEmail.java`](diffhunk://#diff-7af2d73f83e6f1dbb071efca2b53cad3de1ffdca892cc0c54837b204545e529dR1-R66): Introduced a new `MarkdownEmail` model to process markdown emails, including methods for creating instances from files or strings, validating the email, and rendering markdown to HTML.

### PublicController Tests:

* [`src/test/java/com/tailwind/mail/controllers/PublicControllerTests.java`](diffhunk://#diff-4be7a31c92e916f1daf1d16360541366348a9369d9c251a05f57617990418aaeR1-R57): Added test cases for the `PublicController` endpoints to ensure they function correctly, including tests for `about`, `signup`, `unsubscribe`, and `linkClicked` methods.