### PR TITLE
Add Broadcast model and unit tests for email processing

### DIFF
--- a/server/Models/broadcast.py
+++ b/server/Models/broadcast.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from typing import Optional
+import sqlite3
+
+class Broadcast:
+    def __init__(self, id: Optional[int] = None, email_id: Optional[int] = None, status: str = "pending",
+                 name: Optional[str] = None, slug: Optional[str] = None, reply_to: Optional[str] = None,
+                 send_to_tag: str = "*", created_at: datetime = datetime.utcnow()):
+        self.id = id
+        self.email_id = email_id
+        self.status = status
+        self.name = name
+        self.slug = slug
+        self.reply_to = reply_to
+        self.send_to_tag = send_to_tag
+        self.created_at = created_at
+
+    @staticmethod
+    def from_markdown_email(doc):
+        if doc is None or doc.data is None:
+            raise ValueError("MarkdownEmail document cannot be null")
+
+        return Broadcast(
+            name=doc.data.subject,
+            slug=doc.data.slug,
+            send_to_tag=doc.data.send_to_tag
+        )
+
+    @staticmethod
+    def from_markdown(markdown: str):
+        if not markdown.strip():
+            raise ValueError("Markdown content cannot be null or empty")
+
+        doc = MarkdownEmail.from_string(markdown)
+        return Broadcast.from_markdown_email(doc)
+
+    def contact_count(self, conn: sqlite3.Connection) -> int:
+        if conn is None:
+            raise ValueError("Database connection cannot be null")
+
+        contacts = 0
+        try:
+            if self.send_to_tag == "*":
+                contacts = conn.execute("SELECT COUNT(1) FROM contacts WHERE subscribed = 1").fetchone()[0]
+            else:
+                sql = """
+                    SELECT COUNT(1) AS count FROM contacts 
+                    INNER JOIN tagged ON tagged.contact_id = contacts.id
+                    INNER JOIN tags ON tags.id = tagged.tag_id
+                    WHERE subscribed = 1
+                    AND tags.slug = ?
+                """
+                contacts = conn.execute(sql, (self.send_to_tag,)).fetchone()[0]
+        except Exception as ex:
+            # Log the exception (logging mechanism not shown here)
+            raise RuntimeError("An error occurred while counting contacts") from ex
+
+        return contacts

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -1,0 +1,59 @@
+import unittest
+from datetime import datetime
+from server.models.broadcast import Broadcast
+import sqlite3
+
+class TestBroadcast(unittest.TestCase):
+
+    def test_from_markdown_email(self):
+        class MockMarkdownEmail:
+            class Data:
+                subject = "Test Subject"
+                slug = "test-slug"
+                send_to_tag = "test-tag"
+            data = Data()
+
+        doc = MockMarkdownEmail()
+        broadcast = Broadcast.from_markdown_email(doc)
+        self.assertEqual(broadcast.name, "Test Subject")
+        self.assertEqual(broadcast.slug, "test-slug")
+        self.assertEqual(broadcast.send_to_tag, "test-tag")
+
+    def test_from_markdown(self):
+        class MockMarkdownEmail:
+            class Data:
+                subject = "Test Subject"
+                slug = "test-slug"
+                send_to_tag = "test-tag"
+            data = Data()
+
+            @staticmethod
+            def from_string(markdown):
+                return MockMarkdownEmail()
+
+        markdown = "Some markdown content"
+        Broadcast.MarkdownEmail = MockMarkdownEmail
+        broadcast = Broadcast.from_markdown(markdown)
+        self.assertEqual(broadcast.name, "Test Subject")
+        self.assertEqual(broadcast.slug, "test-slug")
+        self.assertEqual(broadcast.send_to_tag, "test-tag")
+
+    def test_contact_count(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE contacts (id INTEGER PRIMARY KEY, subscribed BOOLEAN)")
+        conn.execute("CREATE TABLE tagged (contact_id INTEGER, tag_id INTEGER)")
+        conn.execute("CREATE TABLE tags (id INTEGER PRIMARY KEY, slug TEXT)")
+        conn.execute("INSERT INTO contacts (subscribed) VALUES (1), (1), (0)")
+        conn.execute("INSERT INTO tags (id, slug) VALUES (1, 'test-tag')")
+        conn.execute("INSERT INTO tagged (contact_id, tag_id) VALUES (1, 1), (2, 1)")
+
+        broadcast = Broadcast(send_to_tag="test-tag")
+        count = broadcast.contact_count(conn)
+        self.assertEqual(count, 2)
+
+        broadcast = Broadcast(send_to_tag="*")
+        count = broadcast.contact_count(conn)
+        self.assertEqual(count, 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new `Broadcast` class in the `server/Models/broadcast.py` file, along with corresponding unit tests in `tests/test_broadcast.py`. The changes include defining the `Broadcast` class with various attributes and methods, and adding tests to ensure the functionality of these methods.

New `Broadcast` class and methods:

* [`server/Models/broadcast.py`](diffhunk://#diff-bcbd9b65ded07d0782326cc2fbf9cf5c42b7a567f13ee0fc3633abc62301adc9R1-R58): Added the `Broadcast` class with attributes such as `id`, `email_id`, `status`, `name`, `slug`, `reply_to`, `send_to_tag`, and `created_at`. Included methods `from_markdown_email`, `from_markdown`, and `contact_count` to handle different functionalities related to broadcasts.

Unit tests for `Broadcast` class:

* [`tests/test_broadcast.py`](diffhunk://#diff-3ff24a0d6635bc74db5ca3c3537e5d7c3e36e87936cc11a1c81ff7256e53a2baR1-R59): Added unit tests for the `Broadcast` class to test the `from_markdown_email`, `from_markdown`, and `contact_count` methods. This includes setting up a mock database and verifying the correctness of contact counting based on different tags.