### PR TITLE
Add transactional email functionality with routes and command impleme…

### DIFF
--- a/server/Api/Admin/TransactionalRoutes.cs
+++ b/server/Api/Admin/TransactionalRoutes.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Mvc;
+using Tailwind.Data;
+using Tailwind.Mail.Commands;
+using Tailwind.Mail.Models;
+using Tailwind.Mail.Services;
+
+namespace Tailwind.Mail.Api.Admin;
+
+/// <summary>Response returned after attempting a transactional send.</summary>
+public class TransactionalEmailResponse
+{
+    public bool Success { get; set; }
+    public string? Message { get; set; }
+    public CommandResult? Result { get; set; }
+}
+
+public class TransactionalRoutes
+{
+    private TransactionalRoutes() { }
+
+    public static void MapRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/admin/transact", async (
+            [FromBody] TransactionalEmailRequest req,
+            [FromServices] IDb db,
+            [FromServices] IEmailSender sender) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.To) ||
+                string.IsNullOrWhiteSpace(req.Subject) ||
+                string.IsNullOrWhiteSpace(req.Html))
+            {
+                return Results.BadRequest(new TransactionalEmailResponse
+                {
+                    Success = false,
+                    Message = "To, Subject, and Html are required."
+                });
+            }
+
+            using var conn = db.Connect();
+            var cmd = new SendTransactionalEmailCommand(req);
+            var result = await cmd.Execute(conn, sender);
+
+            var success = result.Inserted > 0;
+            return Results.Ok(new TransactionalEmailResponse
+            {
+                Success = success,
+                Message = success ? $"Email sent to {req.To}" : "Send failed",
+                Result = result
+            });
+        })
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Send a transactional email";
+            op.Description = "Sends a single triggered email (e.g. purchase confirmation) directly to a recipient without an unsubscribe link.";
+            op.RequestBody.Description = "Recipient address, subject, and HTML body";
+            return op;
+        })
+        .Produces<TransactionalEmailResponse>(StatusCodes.Status200OK)
+        .Produces<TransactionalEmailResponse>(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/server/Commands/SendTransactionalEmailCommand.cs
+++ b/server/Commands/SendTransactionalEmailCommand.cs
@@ -1,0 +1,68 @@
+using System.Data;
+using Dapper;
+using Tailwind.Data;
+using Tailwind.Mail.Api.Admin;
+using Tailwind.Mail.Models;
+using Tailwind.Mail.Services;
+
+namespace Tailwind.Mail.Commands;
+
+/// <summary>
+/// Sends a single transactional email directly to a recipient without an unsubscribe link.
+/// Use this for purchase confirmations, password resets, and other triggered emails.
+/// </summary>
+public class SendTransactionalEmailCommand
+{
+    public TransactionalEmailRequest Request { get; set; }
+
+    public SendTransactionalEmailCommand(TransactionalEmailRequest request)
+    {
+        Request = request;
+    }
+
+    public async Task<CommandResult> Execute(IDbConnection conn, IEmailSender sender)
+    {
+        var config = Viper.Config();
+        var defaultFrom = config.Get("DEFAULT_FROM") ?? "noreply@tailwind.dev";
+
+        var message = new Message
+        {
+            Source = "transactional",
+            Slug = $"transact-{Guid.NewGuid()}",
+            SendTo = Request.To,
+            SendFrom = Request.From ?? defaultFrom,
+            Subject = Request.Subject,
+            Html = Request.Html,
+            SendAt = DateTimeOffset.UtcNow
+        };
+
+        try
+        {
+            var sent = await sender.Send(message);
+            var id = await conn.InsertAsync(sent);
+
+            return new CommandResult
+            {
+                Inserted = 1,
+                Data = new
+                {
+                    Success = true,
+                    MessageId = id,
+                    SentTo = sent.SendTo,
+                    SentAt = sent.SentAt
+                }
+            };
+        }
+        catch (Exception e)
+        {
+            return new CommandResult
+            {
+                Data = new
+                {
+                    Success = false,
+                    Message = e.Message
+                }
+            };
+        }
+    }
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -47,6 +47,7 @@ Tailwind.Mail.Api.PublicRoutes.MapRoutes(app);
 Tailwind.Mail.Api.Admin.BroadcastRoutes.MapRoutes(app);
 Tailwind.Mail.Api.Admin.ContactRoutes.MapRoutes(app);
 Tailwind.Mail.Api.Admin.BulkOperationRoutes.MapRoutes(app);
+Tailwind.Mail.Api.Admin.TransactionalRoutes.MapRoutes(app);
 
 app.Run();
 

--- a/server/README.md
+++ b/server/README.md
@@ -40,4 +40,4 @@ Here are the scenarios we're trying to hit with the first release:
  - [x] **Jill queues a broadcast to 10K contacts**. Jill has 10,001 contacts in her database with one opting out. The app should queue up 10K messages for send.
  - [x] **Jim wants to signup to Jill's list**. He submits a form and is sent a double opt-in link to confirm his signup.
  - [x] **Kim gets too much email** and decides to opt out using an unsub link.
- - [ ] **Jill sends a transactional email** to people who buy her book. These are sent individually without an unsub link.
+ - [x] **Jill sends a transactional email** to people who buy her book. These are sent individually without an unsub link.


### PR DESCRIPTION
This pull request introduces support for sending transactional emails, allowing admins to send individual emails (such as purchase confirmations) directly to recipients without an unsubscribe link. The main changes include adding a new API route for transactional email sends, implementing the command logic for sending and recording these emails, and updating documentation and routing to reflect the new feature.

Transactional email feature:

* Added the `TransactionalRoutes` class in `server/Api/Admin/TransactionalRoutes.cs` to define a new `/admin/transact` POST endpoint for sending transactional emails, including request validation and OpenAPI documentation.
* Implemented the `SendTransactionalEmailCommand` in `server/Commands/SendTransactionalEmailCommand.cs` to handle sending transactional emails and recording the result in the database, with error handling and success response structure.

Routing and documentation updates:

* Registered the new transactional email route in `server/Program.cs` so it is available in the application.
* Updated `server/README.md` to mark the transactional email scenario as implemented for the first release.…ntation